### PR TITLE
Prevented random fatal error on php 5.6

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label' => 'Open ID library',
     'description' => 'TAO Open ID library and helpers',
     'license' => 'GPL-2.0',
-    'version' => '0.3.1',
+    'version' => '0.3.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=7.37.1'

--- a/model/SessionService.php
+++ b/model/SessionService.php
@@ -22,7 +22,6 @@
 
 namespace oat\taoOpenId\model;
 
-use Lcobucci\JWT\Token;
 use oat\taoOpenId\model\session\Generator;
 use oat\taoOpenId\model\session\OpenIdAwareSessionInterface;
 use common_session_SessionManager;
@@ -56,7 +55,7 @@ class SessionService extends ConfigurableService
     }
 
     /***
-     * @return Token|null
+     * @return \Lcobucci\JWT\Token|null
      * @throws \common_exception_Error
      */
     public function retrieveSessionToken()

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -83,5 +83,8 @@ class Updater extends \common_ext_ExtensionUpdater
             OntologyUpdater::syncModels();
             $this->setVersion('0.3.1');
         }
+
+        $this->skip('0.3.1', '0.3.2');
+
     }
 }


### PR DESCRIPTION
On taocloud.org server, we've got periodically "Cannot use Lcobucci\JWT\Token as Token because the name is already in use"